### PR TITLE
address: add group option to multitxs for getting txs by address

### DIFF
--- a/lib/addresses.js
+++ b/lib/addresses.js
@@ -4,6 +4,7 @@ var bitcore = require('bitcore-lib-dash');
 var async = require('async');
 var TxController = require('./transactions');
 var Common = require('./common');
+var _ = require('lodash');
 
 function AddressController(node) {
   this.node = node;
@@ -169,8 +170,30 @@ AddressController.prototype.transformUtxo = function(utxoArg) {
   return utxo;
 };
 
+AddressController.prototype._getMultiTxsByAddress = function(groupByAddress, addrs, options, callback) {
+    var self = this;
+  if (!groupByAddress) {
+    callback();
+    return;
+  }
+  async.map(addrs, function(addr, next) {
+    self.node.getAddressHistory(addr, options, function(err, result) {
+      if(err) {
+        return next(err);
+      }
+      self.transformAddressHistoryForMultiTxs(result.items, next);
+    });
+  }, function(err, results){
+    if (err) {
+      return callback(err);
+    }
+    callback(null, _.zipObject(addrs, results));
+  });
+};
+
 AddressController.prototype.multitxs = function(req, res, next) {
-  var self = this;
+  var self = this,
+    groupByAddress = req.query.group === '1';
 
   var options = {
     from: parseInt(req.query.from) || parseInt(req.body.from) || 0
@@ -187,11 +210,20 @@ AddressController.prototype.multitxs = function(req, res, next) {
       if (err) {
         return self.common.handleErrors(err, res);
       }
-      res.jsonp({
-        totalItems: result.totalCount,
-        from: options.from,
-        to: Math.min(options.to, result.totalCount),
-        items: items
+      self._getMultiTxsByAddress(groupByAddress, req.addrs, options, function(err, byAddress) {
+        if (err) {
+          return self.common.handleErrors(err, res);
+        }
+        var response = {
+          totalItems: result.totalCount,
+          from: options.from,
+          to: Math.min(options.to, result.totalCount),
+          items: items
+        };
+        if (byAddress) {
+          response.byAddress = byAddress;
+        }
+        res.jsonp(response);
       });
     });
 


### PR DESCRIPTION
Add a parameter "group" to [the endpoint](https://github.com/bitpay/insight-api#transactions-for-multiple-addresses) **/addrs/[:addrs]/txs[?from=x&to=y]** such that when calling with group=1, the response object has an extra field "byAddress", which is an object that has txid as key, and an array of transactions as value.

**Example:**

Calling with group=0 (or omitting the group parameter):

Request:
/api/addrs/XnWtb5W8Fzih5GNaX6KmKxpFNgF3wrQpMe,XgYGuninVE2ZHLPHzaverZr5QW2F3GkRu8/txs?from=0&to=10

Response:

```
{ 
  "totalItems":23,
  "from":0,
  "to":10,
  "items": <Array with 10 transactions>
}
```

Calling with group=1

Request:
/api/addrs/XnWtb5W8Fzih5GNaX6KmKxpFNgF3wrQpMe,XgYGuninVE2ZHLPHzaverZr5QW2F3GkRu8/txs?from=0&to=10&group=1

Response:

```
{ 
  "totalItems":23,
  "from":0,
  "to":10,
  "items": <Array with 10 transactions>,
  "byAddress": {
    "XnWtb5W8Fzih5GNaX6KmKxpFNgF3wrQpMe": <Array with 10 txs related to XnWtb5...>,
    "XgYGuninVE2ZHLPHzaverZr5QW2F3GkRu8": <Array with 10 txs related to XgYGun...>
  }
}

```
