### PR TITLE
revert change to check status property

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -11,11 +11,7 @@ Common.prototype.notReady = function (err, res, p) {
 Common.prototype.handleErrors = function (err, res) {
   if (err) {
     if (err.code)  {
-      if(res.hasOwnProperty('status')){
-        res.status(400).send(err.message + '. Code:' + err.code);
-      }else{
-        console.warn('Unable to send error code');
-      }
+      res.status(400).send(err.message + '. Code:' + err.code);
     } else {
       this.log.error(err.stack);
       res.status(503).send(err.message);

--- a/test/transactions.js
+++ b/test/transactions.js
@@ -222,7 +222,7 @@ describe('Transactions', function() {
         getDetailedTransaction: function(txid, callback) {
           const err = {
             message: 'Transaction Not Found',
-            code: -5,
+            code: -7,
           };
           return callback(err, null);
         },
@@ -240,13 +240,12 @@ describe('Transactions', function() {
         params: { txid }
       };
 
-      var next = function() {
-        // TODO HERE: ensure that res.statusCode is 400
-        // var merged = _.merge(req.transaction, todos);
-        // should(merged).eql(insight);
-        done();
-      };
+      const next = function() {
+        return;
+      }
       transactions.transaction(req, res, next);
+      should(res.statusCode).eql(400);
+      done();
     })
   });
 

--- a/test/transactions.js
+++ b/test/transactions.js
@@ -202,6 +202,52 @@ describe('Transactions', function() {
 
       transactions.transaction(req, res, next);
     });
+
+    it('should return 400 if txid not found', function(done) {
+      class HTTPMockResponse {
+        status(httpStatusCode) {
+          this.statusCode = httpStatusCode;
+          return this;
+        }
+        send(msg) {
+          return;
+        }
+        jsonp(data) {
+          return;
+        }
+      }
+      let res = new HTTPMockResponse();
+
+      let node = {
+        getDetailedTransaction: function(txid, callback) {
+          const err = {
+            message: 'Transaction Not Found',
+            code: -5,
+          };
+          return callback(err, null);
+        },
+        services: {
+          dashd: {
+            height: 534203
+          },
+        },
+        network: 'testnet'
+      };
+
+      var transactions = new TxController(node);
+      var txid = '0000000000000000000000000000000000000000000000000000000000000001';
+      var req = {
+        params: { txid }
+      };
+
+      var next = function() {
+        // TODO HERE: ensure that res.statusCode is 400
+        // var merged = _.merge(req.transaction, todos);
+        // should(merged).eql(insight);
+        done();
+      };
+      transactions.transaction(req, res, next);
+    })
   });
 
   describe('/txs', function() {


### PR DESCRIPTION
This should be `res.status`'ing every time. If res.status() doesn't exist, we
should have a larger issue as `res` is of the incorrect type, right?