### PR TITLE
[EV-1035] fix returns the swapped search structure

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -23,30 +23,33 @@ SearchController.prototype.swap = function(theArray, indexA, indexB) {
 
 SearchController.prototype.defineSearchType = function(searchString) {
   var self = this;
+  var searchTypeArray = self.searchTypeArray.slice();
   if (searchString.length == 64) {
     if(!searchString.match(/^00/))
     {
-      self.swap(self.searchTypeArray, 0, 1);
+      self.swap(searchTypeArray, 0, 1);
     }
   } else if (searchString.length == 38 || searchString.length === 34) {
-    self.swap(self.searchTypeArray, 0, 2);
+    self.swap(searchTypeArray, 0, 2);
   }
   if (isFinite(searchString)) {
-    self.swap(self.searchTypeArray, 0, 3);
+    self.swap(searchTypeArray, 0, 3);
   }
+  return searchTypeArray;
 }
 
 SearchController.prototype.index = function(req, res) {
   var self = this;
+  var searchTypeArray = false;
   if (typeof req.params != "undefined") {
     if (typeof req.params.searchstr != "undefined") {
-      self.defineSearchType(req.params.searchstr);
+      searchTypeArray = self.defineSearchType(req.params.searchstr);
     }
   }
-  if (self.searchTypeArray) {
+  if (searchTypeArray) {
     res.jsonp({
       status: 200,
-      data: self.searchTypeArray
+      data: searchTypeArray
     });
   } else {
     self.common.handleErrors(new Error("Can't determine search type"), res);

--- a/lib/search.js
+++ b/lib/search.js
@@ -45,17 +45,14 @@ SearchController.prototype.index = function(req, res) {
     if (typeof req.params.searchstr != "undefined") {
       searchTypeArray = self.defineSearchType(req.params.searchstr);
     }
-  } else {
+  }
+  if (!searchTypeArray) {
     searchTypeArray = self.searchTypeArray.slice();
   }
-  if (searchTypeArray) {
-    res.jsonp({
-      status: 200,
-      data: searchTypeArray
-    });
-  } else {
-    self.common.handleErrors(new Error("Can't determine search type"), res);
-  }
+  res.jsonp({
+    status: 200,
+    data: searchTypeArray
+  });
 };
 
 module.exports = SearchController;

--- a/lib/search.js
+++ b/lib/search.js
@@ -40,11 +40,13 @@ SearchController.prototype.defineSearchType = function(searchString) {
 
 SearchController.prototype.index = function(req, res) {
   var self = this;
-  var searchTypeArray = false;
+  var searchTypeArray = false; 
   if (typeof req.params != "undefined") {
     if (typeof req.params.searchstr != "undefined") {
       searchTypeArray = self.defineSearchType(req.params.searchstr);
     }
+  } else {
+    searchTypeArray = self.searchTypeArray.slice();
   }
   if (searchTypeArray) {
     res.jsonp({


### PR DESCRIPTION
Fix for First query to insight-api/search/xxxx returns the proper type of xxxx (address, Tx etc…) but second query returns the swapped structure.