### PR TITLE
travis: fix travis, only LTS Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
+sudo: false
+dist: trusty
 language: node_js
 node_js:
-  - 'v4'
   - '6'
-  - '7'
   - '8'
+  - '10'
+
 install:
   - npm install


### PR DESCRIPTION
* explicitly state sudo not required and use Ubuntu trusty
* only test Node.js LTS versions
