### PR TITLE
add fromHeight/toHeight params to tx history & summary

### DIFF
--- a/lib/addresses.js
+++ b/lib/addresses.js
@@ -185,6 +185,8 @@ AddressController.prototype.multitxs = function(req, res, next) {
   };
 
   options.to = parseInt(req.query.to) || parseInt(req.body.to) || parseInt(options.from) + 10;
+  options.fromHeight = parseInt(req.query.fromHeight) || parseInt(req.body.fromHeight) || undefined;
+  options.toHeight = parseInt(req.query.toHeight) || parseInt(req.body.toHeight) || undefined;
 
   self.node.getAddressHistory(req.addrs, options, function(err, result) {
     if(err) {
@@ -197,12 +199,19 @@ AddressController.prototype.multitxs = function(req, res, next) {
       if (err) {
         return self.common.handleErrors(err, res);
       }
-      res.jsonp({
+      const txHistory = {
         totalItems: result.totalCount,
         from: options.from,
-        to: Math.min(options.to, result.totalCount),
-        items: items
-      });
+        to: Math.min(options.to, result.totalCount)
+      };
+      if (options.fromHeight !== undefined){
+        txHistory.fromHeight = options.fromHeight;
+      }
+      if (options.toHeight !== undefined){
+        txHistory.toHeight = options.toHeight;
+      }
+      txHistory.items = items;
+      res.jsonp(txHistory);
     });
 
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@dashevo/insight-api",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@dashevo/dashcore-lib": {
-      "version": "0.16.10",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.16.10.tgz",
-      "integrity": "sha512-DX6e0SdEoIW4QiibW27HDtJGLhKj/iuNIndwLtHVOjYR/tt5jlx8UiDwH/kpidw7uaPK+IZw4cvLoalTzXwr6w==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.17.0.tgz",
+      "integrity": "sha512-iYvrfbkDKjxzGIZmLb1ROYmdDjY99hkHwFTW8DztHISyTTlN1C7t2LnhsB7yDy5lIz4OeQ2yFKDybJdTIQE9Kw==",
       "requires": {
         "@dashevo/x11-hash-js": "^1.0.2",
         "bn.js": "=4.11.8",
@@ -961,14 +961,14 @@
       "dev": true
     },
     "sinon": {
-      "version": "7.2.7",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.7.tgz",
-      "integrity": "sha512-rlrre9F80pIQr3M36gOdoCEWzFAMDgHYD8+tocqOw+Zw9OZ8F84a80Ds69eZfcjnzDqqG88ulFld0oin/6rG/g==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.0.tgz",
+      "integrity": "sha512-0pYvgRv46fODzT/PByqb79MVNpyxsxf38WEiXTABOF8RfIMcIARfZ+1ORuxwAmHkreZ/jST3UDBdKCRhUy/e1A==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.3.1",
+        "@sinonjs/commons": "^1.4.0",
         "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/samsam": "^3.2.0",
+        "@sinonjs/samsam": "^3.3.0",
         "diff": "^3.5.0",
         "lolex": "^3.1.0",
         "nise": "^1.4.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/insight-api",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -24,9 +24,9 @@
       "integrity": "sha512-3vvnZweBca4URBXHF+FTrM4sdTpp3IMt73G1zUKQEdYm/kJkIKN94qpFai7YZDl87k64RCH+ckRZk6ruQPz5KQ=="
     },
     "@sinonjs/commons": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.1.tgz",
-      "integrity": "sha512-rgmZk5CrBGAMATk0HlHOFvo8V44/r+On6cKS80tqid0Eljd+fFBWBOXZp9H2/EB3faxdNdzXTx6QZIKLkbJ7mA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -43,9 +43,9 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.2.0.tgz",
-      "integrity": "sha512-j5F1rScewLtx6pbTK0UAjA3jJj4RYiSKOix53YWv+Jzy/AZ69qHxUpU8fwVLjyKbEEud9QrLpv6Ggs7WqTimYw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.0.tgz",
+      "integrity": "sha512-beHeJM/RRAaLLsMJhsCvHK31rIqZuobfPLa/80yGH5hnD8PV1hyh9xJBJNFfNmO7yWqm+zomijHsXpI6iTQJfQ==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/insight-api",
   "description": "A Dash blockchain REST and WebSocket API Service",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "repository": "git://github.com/dashevo/insight-api.git",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/insight-api",
   "description": "A Dash blockchain REST and WebSocket API Service",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "repository": "git://github.com/dashevo/insight-api.git",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "async": "^2.6.1",
-    "@dashevo/dashcore-lib": "^0.16.8",
+    "@dashevo/dashcore-lib": "^0.17.0",
     "body-parser": "^1.18.3",
     "compression": "^1.7.3",
     "lodash": "^4.17.11",


### PR DESCRIPTION
In order to activate the optional parameters `fromHeight`/`toHeight` for the dapi endpoint `getTransactionsByAddress` & `getAddressSummary` these need to be parsed and passed in the options object to dashcore-node

Please also review corresponding dapi and dashcore-node PRs
https://github.com/dashevo/dashcore-node/pull/55
https://github.com/dashevo/dapi/pull/150
https://github.com/dashevo/dapi/pull/160

and dapi-client
https://github.com/dashevo/dapi-client/pull/50