### PR TITLE
Enhance address summary endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ Example response:
   /insight-api/addr/[:addr][?noTxList=1][&from=&to=]
   /insight-api/addr/ybi3gej7Ea1MysEYLR7UMs3rMuLJH5aVsW?noTxList=1
   /insight-api/addr/yPv7h2i8v3dJjfSH4L3x91JSJszjdbsJJA?from=1000&to=2000
+  
+  /insight-api/addrs/[:addrs][?noTxList=1][&from=&to=]
+  /insight-api/addrs/ygwNQgE5f15Ygopbs2KPRYMS4TcffqBpsz,ygw5yCtVkx3hREke4L8qDqQtnNoAiPKTSx
+  /insight-api/addrs/ygwNQgE5f15Ygopbs2KPRYMS4TcffqBpsz,ygw5yCtVkx3hREke4L8qDqQtnNoAiPKTSx?from=1000&to=2000
 ```
 
 ### Address Properties
@@ -208,6 +212,11 @@ Example response:
   /insight-api/addr/[:addr]/totalReceived
   /insight-api/addr/[:addr]/totalSent
   /insight-api/addr/[:addr]/unconfirmedBalance
+  
+  /insight-api/addrs/[:addrs]/balance
+  /insight-api/addrs/[:addrs]/totalReceived
+  /insight-api/addrs/[:addrs]/totalSent
+  /insight-api/addrs/[:addrs]/unconfirmedBalance
 ```
 
 The response contains the value in Satoshis.

--- a/lib/addresses.js
+++ b/lib/addresses.js
@@ -77,8 +77,8 @@ AddressController.prototype.getAddressSummary = function(address, options, callb
       totalSentSat: summary.totalSpent,
       unconfirmedBalance: summary.unconfirmedBalance / 1e8,
       unconfirmedBalanceSat: summary.unconfirmedBalance,
-      unconfirmedAppearances: summary.unconfirmedAppearances, // misspelling - ew
-      txAppearances: summary.appearances, // yuck
+      unconfirmedAppearances: summary.unconfirmedAppearances,
+      txAppearances: summary.appearances,
       transactions: summary.txids
     };
 

--- a/lib/addresses.js
+++ b/lib/addresses.js
@@ -21,8 +21,9 @@ AddressController.prototype.show = function(req, res) {
     options.from = parseInt(req.query.from);
     options.to = parseInt(req.query.to);
   }
+  var addresses = req.addr ? req.addr : req.addrs;
 
-  this.getAddressSummary(req.addr, options, function(err, data) {
+  this.getAddressSummary(addresses, options, function(err, data) {
     if(err) {
       return self.common.handleErrors(err, res);
     }
@@ -49,7 +50,8 @@ AddressController.prototype.unconfirmedBalance = function(req, res) {
 
 AddressController.prototype.addressSummarySubQuery = function(req, res, param) {
   var self = this;
-  this.getAddressSummary(req.addr, {}, function(err, data) {
+  var addresses = req.addr ? req.addr : req.addrs;
+  this.getAddressSummary(addresses, {}, function(err, data) {
     if(err) {
       return self.common.handleErrors(err, res);
     }

--- a/lib/addresses.js
+++ b/lib/addresses.js
@@ -77,8 +77,8 @@ AddressController.prototype.getAddressSummary = function(address, options, callb
       totalSentSat: summary.totalSpent,
       unconfirmedBalance: summary.unconfirmedBalance / 1e8,
       unconfirmedBalanceSat: summary.unconfirmedBalance,
-      unconfirmedAppearances: summary.unconfirmedAppearances,
-      txAppearances: summary.appearances,
+      unconfirmedAppearances: summary.unconfirmedAppearances, // misspelling - ew
+      txAppearances: summary.appearances, // yuck
       transactions: summary.txids
     };
 

--- a/lib/addresses.js
+++ b/lib/addresses.js
@@ -77,8 +77,8 @@ AddressController.prototype.getAddressSummary = function(address, options, callb
       totalSentSat: summary.totalSpent,
       unconfirmedBalance: summary.unconfirmedBalance / 1e8,
       unconfirmedBalanceSat: summary.unconfirmedBalance,
-      unconfirmedTxApperances: summary.unconfirmedAppearances, // misspelling - ew
-      txApperances: summary.appearances, // yuck
+      unconfirmedAppearances: summary.unconfirmedAppearances,
+      txAppearances: summary.appearances,
       transactions: summary.txids
     };
 

--- a/lib/addresses.js
+++ b/lib/addresses.js
@@ -77,7 +77,9 @@ AddressController.prototype.getAddressSummary = function(address, options, callb
       totalSentSat: summary.totalSpent,
       unconfirmedBalance: summary.unconfirmedBalance / 1e8,
       unconfirmedBalanceSat: summary.unconfirmedBalance,
+      unconfirmedTxApperances: summary.unconfirmedAppearances,
       unconfirmedAppearances: summary.unconfirmedAppearances,
+      txApperances: summary.appearances,
       txAppearances: summary.appearances,
       transactions: summary.txids
     };

--- a/lib/addresses.js
+++ b/lib/addresses.js
@@ -77,9 +77,9 @@ AddressController.prototype.getAddressSummary = function(address, options, callb
       totalSentSat: summary.totalSpent,
       unconfirmedBalance: summary.unconfirmedBalance / 1e8,
       unconfirmedBalanceSat: summary.unconfirmedBalance,
-      unconfirmedTxApperances: summary.unconfirmedAppearances,
+      unconfirmedTxApperances: summary.unconfirmedAppearances,  // will be deprecated in a future update
       unconfirmedAppearances: summary.unconfirmedAppearances,
-      txApperances: summary.appearances,
+      txApperances: summary.appearances, // will be deprecated in a future update
       txAppearances: summary.appearances,
       transactions: summary.txids
     };

--- a/lib/index.js
+++ b/lib/index.js
@@ -211,6 +211,7 @@ InsightAPI.prototype.setupRoutes = function(app) {
   // Address routes
   var addresses = new AddressController(this.node);
   app.get('/addr/:addr', this.cacheShort(), addresses.checkAddr.bind(addresses), addresses.show.bind(addresses));
+  app.get('/addr/:addrs', this.cacheShort(), addresses.checkAddrs.bind(addresses), addresses.show.bind(addresses));
   app.get('/addr/:addr/utxo', this.cacheShort(), addresses.checkAddr.bind(addresses), addresses.utxo.bind(addresses));
   app.get('/addrs/:addrs/utxo', this.cacheShort(), addresses.checkAddrs.bind(addresses), addresses.multiutxo.bind(addresses));
   app.post('/addrs/utxo', this.cacheShort(), addresses.checkAddrs.bind(addresses), addresses.multiutxo.bind(addresses));

--- a/lib/index.js
+++ b/lib/index.js
@@ -211,7 +211,7 @@ InsightAPI.prototype.setupRoutes = function(app) {
   // Address routes
   var addresses = new AddressController(this.node);
   app.get('/addr/:addr', this.cacheShort(), addresses.checkAddr.bind(addresses), addresses.show.bind(addresses));
-  app.get('/addr/:addrs', this.cacheShort(), addresses.checkAddrs.bind(addresses), addresses.show.bind(addresses));
+  app.get('/addrs/:addrs', this.cacheShort(), addresses.checkAddrs.bind(addresses), addresses.show.bind(addresses));
   app.get('/addr/:addr/utxo', this.cacheShort(), addresses.checkAddr.bind(addresses), addresses.utxo.bind(addresses));
   app.get('/addrs/:addrs/utxo', this.cacheShort(), addresses.checkAddrs.bind(addresses), addresses.multiutxo.bind(addresses));
   app.post('/addrs/utxo', this.cacheShort(), addresses.checkAddrs.bind(addresses), addresses.multiutxo.bind(addresses));
@@ -225,6 +225,10 @@ InsightAPI.prototype.setupRoutes = function(app) {
   app.get('/addr/:addr/totalReceived', this.cacheShort(), addresses.checkAddr.bind(addresses), addresses.totalReceived.bind(addresses));
   app.get('/addr/:addr/totalSent', this.cacheShort(), addresses.checkAddr.bind(addresses), addresses.totalSent.bind(addresses));
   app.get('/addr/:addr/unconfirmedBalance', this.cacheShort(), addresses.checkAddr.bind(addresses), addresses.unconfirmedBalance.bind(addresses));
+  app.get('/addrs/:addrs/balance', this.cacheShort(), addresses.checkAddrs.bind(addresses), addresses.balance.bind(addresses));
+  app.get('/addrs/:addrs/totalReceived', this.cacheShort(), addresses.checkAddrs.bind(addresses), addresses.totalReceived.bind(addresses));
+  app.get('/addrs/:addrs/totalSent', this.cacheShort(), addresses.checkAddrs.bind(addresses), addresses.totalSent.bind(addresses));
+  app.get('/addrs/:addrs/unconfirmedBalance', this.cacheShort(), addresses.checkAddrs.bind(addresses), addresses.unconfirmedBalance.bind(addresses));
 
   //Governance Routes
   var govObject = new GovObjectController(this.node);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@dashevo/insight-api",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@dashevo/dashcore-lib": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.16.9.tgz",
-      "integrity": "sha512-BoRgzUarwL291pNzln4VWAvm9vY3YyevXmnOICNOIzswe1MZrHGHnQkwdQ2f4qCFibfhwdO92VTgQFRB6AqaRw==",
+      "version": "0.16.10",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.16.10.tgz",
+      "integrity": "sha512-DX6e0SdEoIW4QiibW27HDtJGLhKj/iuNIndwLtHVOjYR/tt5jlx8UiDwH/kpidw7uaPK+IZw4cvLoalTzXwr6w==",
       "requires": {
         "@dashevo/x11-hash-js": "^1.0.2",
         "bn.js": "=4.11.8",
@@ -24,9 +24,9 @@
       "integrity": "sha512-3vvnZweBca4URBXHF+FTrM4sdTpp3IMt73G1zUKQEdYm/kJkIKN94qpFai7YZDl87k64RCH+ckRZk6ruQPz5KQ=="
     },
     "@sinonjs/commons": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.1.tgz",
-      "integrity": "sha512-rgmZk5CrBGAMATk0HlHOFvo8V44/r+On6cKS80tqid0Eljd+fFBWBOXZp9H2/EB3faxdNdzXTx6QZIKLkbJ7mA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -43,9 +43,9 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.2.0.tgz",
-      "integrity": "sha512-j5F1rScewLtx6pbTK0UAjA3jJj4RYiSKOix53YWv+Jzy/AZ69qHxUpU8fwVLjyKbEEud9QrLpv6Ggs7WqTimYw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.0.tgz",
+      "integrity": "sha512-beHeJM/RRAaLLsMJhsCvHK31rIqZuobfPLa/80yGH5hnD8PV1hyh9xJBJNFfNmO7yWqm+zomijHsXpI6iTQJfQ==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.0.2",
@@ -261,15 +261,15 @@
       }
     },
     "compression": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
-      "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
       "requires": {
         "accepts": "~1.3.5",
         "bytes": "3.0.0",
-        "compressible": "~2.0.14",
+        "compressible": "~2.0.16",
         "debug": "2.6.9",
-        "on-headers": "~1.0.1",
+        "on-headers": "~1.0.2",
         "safe-buffer": "5.1.2",
         "vary": "~1.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/insight-api",
   "description": "A Dash blockchain REST and WebSocket API Service",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "repository": "git://github.com/dashevo/insight-api.git",
   "contributors": [
     {

--- a/test/addresses.js
+++ b/test/addresses.js
@@ -212,7 +212,9 @@ describe('Addresses', function() {
         'totalSentSat': 2782729129,
         'unconfirmedBalance': 0,
         'unconfirmedBalanceSat': 0,
+        'unconfirmedTxApperances': 0,
         'unconfirmedAppearances': 0,
+        'txApperances': 2,
         'txAppearances': 2,
         'transactions': [
           'bb0ec3b96209fac9529570ea6f83a86af2cceedde4aaf2bfcc4796680d23f1c7',

--- a/test/addresses.js
+++ b/test/addresses.js
@@ -212,8 +212,8 @@ describe('Addresses', function() {
         'totalSentSat': 2782729129,
         'unconfirmedBalance': 0,
         'unconfirmedBalanceSat': 0,
-        'unconfirmedTxApperances': 0,
-        'txApperances': 2,
+        'unconfirmedAppearances': 0,
+        'txAppearances': 2,
         'transactions': [
           'bb0ec3b96209fac9529570ea6f83a86af2cceedde4aaf2bfcc4796680d23f1c7',
           '01f700df84c466f2a389440e5eeacdc47d04f380c39e5d19dce2ce91a11ecba3'


### PR DESCRIPTION
- enables input of array of addresses throughout address summary functions/subfunctions
- bumps minor version as breaking change (corrected some minor misspellings in summary)
- adds new endpoints:

**Address**
  /insight-api/addr**s**/[:addr**s**][?noTxList=1][&from=&to=]
  /insight-api/addr**s**/ybi3gej7Ea1MysEYLR7UMs3rMuLJH5aVsW,yPv7h2i8v3dJjfSH4L3x91JSJszjdbsJJA?noTxList=1
  /insight-api/addr**s**/yPv7h2i8v3dJjfSH4L3x91JSJszjdbsJJA,yPv7h2i8v3dJjfSH4L3x91JSJszjdbsJJA?from=1000&to=2000

**Address Properties**
  /insight-api/addr**s**/[:addr**s**]/balance
  /insight-api/addr**s**/[:addr**s**]/totalReceived
  /insight-api/addr**s**/[:addr**s**]/totalSent
  /insight-api/addr**s**/[:addr**s**]/unconfirmedBalance

Please first review and merge https://github.com/dashevo/insight-api/pull/42