### PR TITLE
Fix ISLOCK subscription

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -307,8 +307,7 @@ InsightAPI.prototype.blockEventHandler = function(hashBuffer) {
   }
 };
 InsightAPI.prototype.transactionEventHandler = function(txBuffer) {
-  const txVersion = txBuffer.slice(0, 1).toString('hex');
-  if (txVersion === '01' || txVersion === '02' || txVersion === '03') {
+  try {
     var tx = new Transaction().fromBuffer(txBuffer);
     var result = this.txController.transformInvTransaction(tx);
 
@@ -316,16 +315,21 @@ InsightAPI.prototype.transactionEventHandler = function(txBuffer) {
       this.subscriptions.inv[i].emit('tx', result);
     }
   }
+  catch(error) {
+    console.error(`bad txBuffer ${txbuffer} \\n ${error}`);
+  }
 };
 InsightAPI.prototype.transactionLockEventHandler = function(txBuffer) {
-  const txVersion = txBuffer.slice(0, 1).toString('hex');
-  if (txVersion === '01' || txVersion === '02' || txVersion === '03') {
+  try {
     var tx = new Transaction().fromBuffer(txBuffer);
     var result = this.txController.transformInvTransaction(tx, true);
 
     for (var i = 0; i < this.subscriptions.inv.length; i++) {
       this.subscriptions.inv[i].emit('txlock', result);
     }
+  }
+  catch(error) {
+    console.error(`bad txBuffer ${txbuffer} \\n ${error}`);
   }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -309,27 +309,27 @@ InsightAPI.prototype.blockEventHandler = function(hashBuffer) {
 InsightAPI.prototype.transactionEventHandler = function(txBuffer) {
   try {
     var tx = new Transaction().fromBuffer(txBuffer);
-    var result = this.txController.transformInvTransaction(tx);
-
-    for (var i = 0; i < this.subscriptions.inv.length; i++) {
-      this.subscriptions.inv[i].emit('tx', result);
-    }
   }
   catch(error) {
     console.log(`${error}\nbad txBuffer: ${txBuffer.toString('hex')}`);
+  }
+  var result = this.txController.transformInvTransaction(tx);
+
+  for (var i = 0; i < this.subscriptions.inv.length; i++) {
+    this.subscriptions.inv[i].emit('tx', result);
   }
 };
 InsightAPI.prototype.transactionLockEventHandler = function(txBuffer) {
   try {
     var tx = new Transaction().fromBuffer(txBuffer);
-    var result = this.txController.transformInvTransaction(tx, true);
-
-    for (var i = 0; i < this.subscriptions.inv.length; i++) {
-      this.subscriptions.inv[i].emit('txlock', result);
-    }
   }
   catch(error) {
     console.log(`${error}\nbad txBuffer: ${txBuffer.toString('hex')}`);
+  }
+  var result = this.txController.transformInvTransaction(tx, true);
+
+  for (var i = 0; i < this.subscriptions.inv.length; i++) {
+    this.subscriptions.inv[i].emit('txlock', result);
   }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -316,7 +316,7 @@ InsightAPI.prototype.transactionEventHandler = function(txBuffer) {
     }
   }
   catch(error) {
-    console.error(`bad txBuffer ${txbuffer} \\n ${error}`);
+    console.log(`bad txBuffer: ${txBuffer.toString('hex')} \nerror: \n${error}`);
   }
 };
 InsightAPI.prototype.transactionLockEventHandler = function(txBuffer) {
@@ -329,7 +329,7 @@ InsightAPI.prototype.transactionLockEventHandler = function(txBuffer) {
     }
   }
   catch(error) {
-    console.error(`bad txBuffer ${txbuffer} \\n ${error}`);
+    console.log(`bad txBuffer: ${txBuffer.toString('hex')} \nerror: \n${error}`);
   }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -325,7 +325,7 @@ InsightAPI.prototype.transactionEventHandler = function(txBuffer) {
 };
 InsightAPI.prototype.transactionLockEventHandler = function(txBuffer) {
   var tx = new Transaction().fromBuffer(txBuffer);
-  var result = this.txController.transformInvTransaction(tx);
+  var result = this.txController.transformInvTransaction(tx, true);
 
   for (var i = 0; i < this.subscriptions.inv.length; i++) {
     this.subscriptions.inv[i].emit('txlock', result);

--- a/lib/index.js
+++ b/lib/index.js
@@ -316,7 +316,7 @@ InsightAPI.prototype.transactionEventHandler = function(txBuffer) {
     }
   }
   catch(error) {
-    console.log(`bad txBuffer: ${txBuffer.toString('hex')} \nerror: \n${error}`);
+    console.log(`${error}\nbad txBuffer: ${txBuffer.toString('hex')}`);
   }
 };
 InsightAPI.prototype.transactionLockEventHandler = function(txBuffer) {
@@ -329,7 +329,7 @@ InsightAPI.prototype.transactionLockEventHandler = function(txBuffer) {
     }
   }
   catch(error) {
-    console.log(`bad txBuffer: ${txBuffer.toString('hex')} \nerror: \n${error}`);
+    console.log(`${error}\nbad txBuffer: ${txBuffer.toString('hex')}`);
   }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -310,18 +310,9 @@ InsightAPI.prototype.transactionEventHandler = function(txBuffer) {
   var tx = new Transaction().fromBuffer(txBuffer);
   var result = this.txController.transformInvTransaction(tx);
 
-  setTimeout(function(result, txBuffer) { // delay tx relay for 900ms to see if we receive transaction lock
-    var hash = dashcore.crypto.Hash.sha256sha256(txBuffer);
-    var id = hash.toString('binary');
-
-    if (this.node.services.dashd.zmqKnownTransactionLocks.get(id)) {
-      result.txlock = true;
-    }
-
-    for (var i = 0; i < this.subscriptions.inv.length; i++) {
-      this.subscriptions.inv[i].emit('tx', result);
-    }
-  }.bind(this, result, txBuffer), 900);
+  for (var i = 0; i < this.subscriptions.inv.length; i++) {
+    this.subscriptions.inv[i].emit('tx', result);
+  }
 };
 InsightAPI.prototype.transactionLockEventHandler = function(txBuffer) {
   var tx = new Transaction().fromBuffer(txBuffer);

--- a/lib/index.js
+++ b/lib/index.js
@@ -307,19 +307,25 @@ InsightAPI.prototype.blockEventHandler = function(hashBuffer) {
   }
 };
 InsightAPI.prototype.transactionEventHandler = function(txBuffer) {
-  var tx = new Transaction().fromBuffer(txBuffer);
-  var result = this.txController.transformInvTransaction(tx);
+  const txVersion = txBuffer.slice(0, 1).toString('hex');
+  if (txVersion === '01' || txVersion === '02' || txVersion === '03') {
+    var tx = new Transaction().fromBuffer(txBuffer);
+    var result = this.txController.transformInvTransaction(tx);
 
-  for (var i = 0; i < this.subscriptions.inv.length; i++) {
-    this.subscriptions.inv[i].emit('tx', result);
+    for (var i = 0; i < this.subscriptions.inv.length; i++) {
+      this.subscriptions.inv[i].emit('tx', result);
+    }
   }
 };
 InsightAPI.prototype.transactionLockEventHandler = function(txBuffer) {
-  var tx = new Transaction().fromBuffer(txBuffer);
-  var result = this.txController.transformInvTransaction(tx, true);
+  const txVersion = txBuffer.slice(0, 1).toString('hex');
+  if (txVersion === '01' || txVersion === '02' || txVersion === '03') {
+    var tx = new Transaction().fromBuffer(txBuffer);
+    var result = this.txController.transformInvTransaction(tx, true);
 
-  for (var i = 0; i < this.subscriptions.inv.length; i++) {
-    this.subscriptions.inv[i].emit('txlock', result);
+    for (var i = 0; i < this.subscriptions.inv.length; i++) {
+      this.subscriptions.inv[i].emit('txlock', result);
+    }
   }
 };
 

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -186,7 +186,7 @@ TxController.prototype.transformOutput = function(options, output, index) {
   return transformed;
 };
 
-TxController.prototype.transformInvTransaction = function(transaction) {
+TxController.prototype.transformInvTransaction = function(transaction, isLocked = false) {
   var self = this;
 
   var valueOut = 0;
@@ -213,7 +213,7 @@ TxController.prototype.transformInvTransaction = function(transaction) {
     valueOut: valueOut / 1e8,
     vout: vout,
     isRBF: isRBF,
-    txlock: false
+    txlock: isLocked
   };
 
   return transformed;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/insight-api",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@dashevo/insight-api",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@dashevo/dashcore-lib": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.17.4.tgz",
-      "integrity": "sha512-qj3hCzhRBToXVpGsWhNRun+RC+Y8oGObsd8nDVn9OgO/iFiKMuit8m3lJOlzuaLi6SwHOVhWC+0yU3QG5IW5Ng==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.17.6.tgz",
+      "integrity": "sha512-c8amlnz75CstZV/o4J6KcKQmoFvu0oPnH3jB22XEeCSZezUUdVp9nBlE3+SL966JMbY+XDxLP6nDhJeneFxjMQ==",
       "requires": {
         "@dashevo/x11-hash-js": "^1.0.2",
+        "bloom-filter": "^0.2.0",
         "bn.js": "=4.11.8",
         "bs58": "=4.0.1",
         "elliptic": "=6.4.1",
@@ -43,9 +44,9 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
-      "integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
+      "integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.0.2",
@@ -156,6 +157,11 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "bloom-filter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bloom-filter/-/bloom-filter-0.2.0.tgz",
+      "integrity": "sha1-hNY7v5Fy2DA+ZMH/FuudvzOpgaM="
     },
     "bn.js": {
       "version": "4.11.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/insight-api",
   "description": "A Dash blockchain REST and WebSocket API Service",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "repository": "git://github.com/dashevo/insight-api.git",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "async": "^2.6.1",
+    "async": "^2.6.2",
     "@dashevo/dashcore-lib": "^0.17.6",
-    "body-parser": "^1.18.3",
-    "compression": "^1.7.3",
+    "body-parser": "^1.19.0",
+    "compression": "^1.7.4",
     "lodash": "^4.17.11",
     "lru-cache": "^5.1.1",
     "morgan": "^1.9.1",
@@ -74,6 +74,6 @@
     "mocha": "^5.2.0",
     "proxyquire": "^1.8.0",
     "should": "^13.2.3",
-    "sinon": "^7.1.1"
+    "sinon": "^7.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/insight-api",
   "description": "A Dash blockchain REST and WebSocket API Service",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "repository": "git://github.com/dashevo/insight-api.git",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "async": "^2.6.1",
-    "@dashevo/dashcore-lib": "^0.17.2",
+    "@dashevo/dashcore-lib": "^0.17.6",
     "body-parser": "^1.18.3",
     "compression": "^1.7.3",
     "lodash": "^4.17.11",


### PR DESCRIPTION
This PR is a long overdue fix for the subscriptions to the web socket api which enables 3rd parties to listen to zmq events like the rawtx event and the txlock event.

https://github.com/dashevo/insight-api#web-socket-api

The zmq event handlers were both giving back the same data with the `txlock` attribute always set to `false`. Now that the events are properly distinct and only the `transactionLockEventHandler` has the `txlock` property set to `true`, 3rd parties should again listen to both the `tx` and `txlock` zmq messages in the `inv` room to reliably detect ISLOCKs. Even though with the new llmq based ISLOCK regime it is more a matter of detecting non-ISLOCKed transactions, because almost all should be ISLOCKed. Normally they will now get the `tx` event as soon as a new unconfirmed tx hits the mempool of the dashd daemon the insight server is connected to and then shortly after the ISLOCK confirmation for the same tx with the `txlock` event. Tx hashes which don't appear in the `txlock` event after a few seconds have to be considered as NOT locked and normal confirmation rules apply for judging if they can be considered safe. The above was tested in livenet with non-simple transactions as it is now still possible to use them as a reliable way to produce non-ISLOCKed transactions. Once spork 20 gets activated non-ISLOCKed transactions are a matter of luck (or more likely bad luck).

Fortunately this means we can also also get rid of the quirky hack with the delayed 2nd check in the zmq message cache which would have been in need of a longer wait time under the new llmq islock regime to still have a chance of working a little more often than not.

During testing it was noticed that at least in testnet the `message` received in the `transactionLockEventHandler` would sometimes cause insight-api to crash with the error attached here at the bottom for later reference. Setting up a trace revealed that the error-inducing message was not a transaction at all, but just the name of the zmq event `hashtxlock`. In order to catch and ignore this strange occurance the code now checks if the `txBuffer` parameter resembles a known transaction by checking the version field.

```
[2019-06-18T23:54:04.274Z] error: uncaught exception: RangeError [ERR_OUT_OF_RANGE]: The value of "offset" is out of range. It must be >= 0 and <= 5. Received 37
    at boundsError (internal/buffer.js:53:9)
    at Uint8Array.readUInt32LE (internal/buffer.js:109:5)
    at BufferReader.readUInt32LE (/home/cofresi/insight-api/node_modules/@dashevo/dashcore-lib/lib/encoding/bufferreader.js:81:22)
    at Function.Input.fromBufferReader (/home/cofresi/insight-api/node_modules/@dashevo/dashcore-lib/lib/transaction/input/input.js:94:26)
    at Transaction.fromBufferReader (/home/cofresi/insight-api/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:307:23)
    at Transaction.fromBuffer (/home/cofresi/insight-api/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:297:15)
    at InsightAPI.transactionLockEventHandler (/home/cofresi/insight-api/lib/index.js:327:30)
    at Dash.emit (events.js:182:13)
    at Dash._zmqTransactionLockHandler (/home/cofresi/.nvm/versions/node/v10.13.0/lib/node_modules/@dashevo/dashcore-node/lib/services/dashd.js:710:10)
    at exports.Socket.<anonymous> (/home/cofresi/.nvm/versions/node/v10.13.0/lib/node_modules/@dashevo/dashcore-node/lib/services/dashd.js:780:12)
[2019-06-18T23:54:04.278Z] error: RangeError [ERR_OUT_OF_RANGE]: The value of "offset" is out of range. It must be >= 0 and <= 5. Received 37
    at boundsError (internal/buffer.js:53:9)
    at Uint8Array.readUInt32LE (internal/buffer.js:109:5)
    at BufferReader.readUInt32LE (/home/cofresi/insight-api/node_modules/@dashevo/dashcore-lib/lib/encoding/bufferreader.js:81:22)
    at Function.Input.fromBufferReader (/home/cofresi/insight-api/node_modules/@dashevo/dashcore-lib/lib/transaction/input/input.js:94:26)
    at Transaction.fromBufferReader (/home/cofresi/insight-api/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:307:23)
    at Transaction.fromBuffer (/home/cofresi/insight-api/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:297:15)
    at InsightAPI.transactionLockEventHandler (/home/cofresi/insight-api/lib/index.js:327:30)
    at Dash.emit (events.js:182:13)
    at Dash._zmqTransactionLockHandler (/home/cofresi/.nvm/versions/node/v10.13.0/lib/node_modules/@dashevo/dashcore-node/lib/services/dashd.js:710:10)
    at exports.Socket.<anonymous> (/home/cofresi/.nvm/versions/node/v10.13.0/lib/node_modules/@dashevo/dashcore-node/lib/services/dashd.js:780:12)
```