### PR TITLE
chore: Build all branches in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,6 @@ addons:
     packages:
       - docker-ce
 
-branches:
-  only:
-    - master
-    # Allow builds for version tags (e.g. v1.0.0)
-    - /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-
 before_install:
   # Login to NPM registry
   - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc


### PR DESCRIPTION
I'm not sure why this stanza was introduced in the Travis config but building branches is very useful. This can also be enabled / disabled thru the Travis-CI per-repo settings.