### PR TITLE
feat: build multi-arch docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,14 @@ node_js:
   - '10'
   - '12'
 
-services:
-  - docker
-
 addons:
   apt:
-    packages:
-      - docker-ce
+    update: true
+    sources:
+      - sourceline: 'deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable'
+
+env:
+  - DOCKER_CLI_EXPERIMENTAL=enabled
 
 branches:
   only:
@@ -21,12 +22,15 @@ branches:
     - /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
 
 before_install:
+  - sudo apt-get -y install docker-ce
   # Login to NPM registry
   - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
   # Use latest supported NPM in order to speedup build and support `npm ci`
   - npm i -g npm@6
 
 install:
+  - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+  - docker buildx create --name xbuilder --use
   - npm ci
 
 deploy:

--- a/scripts/travis-deploy.sh
+++ b/scripts/travis-deploy.sh
@@ -29,9 +29,10 @@ npm publish
 IMAGE_NAME="dashpay/insight-api"
 
 # Build Docker image
-docker build -t "${IMAGE_NAME}:latest" \
+docker buildx build -t "${IMAGE_NAME}:latest" \
              -t "${IMAGE_NAME}:${VERSION}" \
              --build-arg "VERSION=${VERSION}" \
+             --platform linux/amd64,linux/arm64,linux/arm/v7 \
              docker
 
 # Login to Docker Hub


### PR DESCRIPTION
Build multi-arch docker images to support ARM architecture

### Issue being fixed or feature implemented
This modifies Travis CI to build ARM images so we can begin to support the evo stack on devices like Raspberry Pi or AWS Graviton2.

### What was done?
Change docker environment and build command to add arm64 and arm/v7 images.

### How Has This Been Tested?
Tested locally with no problems. Tested on Travis from my branch, but was not able to test actually deploying the image to Docker Hub.

### Breaking Changes
Because this requires emulation, it will increase the build time on CI.

### Checklist:
[x] I have performed a self-review of my own code
[x] I have commented my code, particularly in hard-to-understand areas
[ ] I have added or updated relevant unit/integration/functional/e2e tests
[ ] I have made corresponding changes to the documentation
For repository code-owners and collaborators only

[ ] I have assigned this pull request to a milestone