### PR TITLE
feat: getBestChainLock parameter in status endpoint, test, and README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This is a backend-only service. If you're looking for the web frontend applicati
     - [Masternodes List](#masternodes-list)
     - [Historic Blockchain Data Sync Status](#historic-blockchain-data-sync-status)
     - [Live Network P2P Data Sync Status](#live-network-p2p-data-sync-status)
-    - [Status of the Bitcoin Network](#status-of-the-bitcoin-network)
+    - [Status of the Dash Network](#status-of-the-dash-network)
     - [Utility Methods](#utility-methods)
 - [Web Socket Api](#web-socket-api)
     - [Example Usage](#example-usage)
@@ -200,7 +200,7 @@ Example response:
   /insight-api/addr/[:addr][?noTxList=1][&from=&to=]
   /insight-api/addr/ybi3gej7Ea1MysEYLR7UMs3rMuLJH5aVsW?noTxList=1
   /insight-api/addr/yPv7h2i8v3dJjfSH4L3x91JSJszjdbsJJA?from=1000&to=2000
-  
+
   /insight-api/addrs/[:addrs][?noTxList=1][&from=&to=]
   /insight-api/addrs/ygwNQgE5f15Ygopbs2KPRYMS4TcffqBpsz,ygw5yCtVkx3hREke4L8qDqQtnNoAiPKTSx
   /insight-api/addrs/ygwNQgE5f15Ygopbs2KPRYMS4TcffqBpsz,ygw5yCtVkx3hREke4L8qDqQtnNoAiPKTSx?from=1000&to=2000
@@ -213,7 +213,7 @@ Example response:
   /insight-api/addr/[:addr]/totalReceived
   /insight-api/addr/[:addr]/totalSent
   /insight-api/addr/[:addr]/unconfirmedBalance
-  
+
   /insight-api/addrs/[:addrs]/balance
   /insight-api/addrs/[:addrs]/totalReceived
   /insight-api/addrs/[:addrs]/totalSent
@@ -521,7 +521,7 @@ Sample output:
     AbsoluteYesCount: 40,
     YesCount: 40,
     NoCount: 0,
-    AbstainCount: 0 
+    AbstainCount: 0
   }
 ]
 ```
@@ -726,7 +726,7 @@ Sample output:
   /insight-api/peer
 ```
 
-### Status of the Bitcoin Network
+### Status of the Dash Network
 
 ```
   /insight-api/status?q=xxx
@@ -737,6 +737,7 @@ Where "xxx" can be:
  * getInfo
  * getDifficulty
  * getBestBlockHash
+ * getBestChainLock
  * getLastBlockHash
 
 ### Utility Methods
@@ -786,7 +787,7 @@ Sample output:
 }
 ```
 
-`<bitcoinAddress>`: new transaction concerning <bitcoinAddress> received from network. This event is published in the `<bitcoinAddress>` room.
+`<dashAddress>`: new transaction concerning <dashAddress> received from network. This event is published in the `<dashAddress>` room.
 
 `status`: every 1% increment on the sync task, this event will be triggered. This event is published in the `sync` room.
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Example response:
 ```
   /insight-api/tx/[:txid]
   /insight-api/tx/ebdca263fe1c75c8609ce8fe3d82a320a0b3ca840f4df995883f5dab1b9ff8d9
+
   /insight-api/rawtx/[:rawid]
   /insight-api/rawtx/ebdca263fe1c75c8609ce8fe3d82a320a0b3ca840f4df995883f5dab1b9ff8d9
 ```

--- a/lib/status.js
+++ b/lib/status.js
@@ -32,6 +32,14 @@ StatusController.prototype.show = function(req, res) {
       res.jsonp(result);
     });
     break;
+  case 'getBestChainLock':
+    this.getBestChainLock(function (err, result) {
+      if (err) {
+        return self.common.handleErrors(err, res);
+      }
+      res.jsonp(result);
+    });
+    break;
   case 'getInfo':
   default:
     this.getInfo(function(err, result) {
@@ -83,6 +91,17 @@ StatusController.prototype.getBestBlockHash = function(callback) {
     }
     callback(null, {
       bestblockhash: hash
+    });
+  });
+};
+
+StatusController.prototype.getBestChainLock = function (callback) {
+  this.node.services.dashd.getBestChainLock(function (err, result) {
+    if (err) {
+      return callback(err);
+    }
+    callback(null, {
+      bestchainlock: result
     });
   });
 };

--- a/test/status.js
+++ b/test/status.js
@@ -8,7 +8,7 @@ describe('Status', function() {
   describe('/status', function() {
     var info = {
       version: 110000,
-      insightVersion:"0.5.0", 
+      insightVersion:"0.5.0",
       protocolVersion: 70002,
       blocks: 548645,
       timeOffset: 0,
@@ -26,7 +26,12 @@ describe('Status', function() {
       txouts: 151,
       bytes_serialized: 10431,
       hash_serialized: 'c165d5dcb22a897745ee2ee274b47133b995bbcf8dd4a7572fedad87541c7df8',
-      total_amount: 750000000000
+      total_amount: 750000000000,
+      bestchainlock: {
+        blockhash: '20b6cc0600037171b8bb634bbd04ea754945be44db8d9199b74798f1abdb382d',
+        height: 151,
+        known_block: true
+      }
     };
 
     var node = {
@@ -34,6 +39,7 @@ describe('Status', function() {
         dashd: {
           getInfo: sinon.stub().callsArgWith(0, null, info),
           getBestBlockHash: sinon.stub().callsArgWith(0, null, outSetInfo.bestblock),
+          getBestChainLock: sinon.stub().callsArgWith(0, null, outSetInfo.bestchainlock),
           tiphash: outSetInfo.bestblock
         }
       }
@@ -88,6 +94,21 @@ describe('Status', function() {
       var res = {
         jsonp: function(data) {
           data.bestblockhash.should.equal(outSetInfo.bestblock);
+          done();
+        }
+      };
+      status.show(req, res);
+    });
+
+    it('getBestChainLock', function (done) {
+      var req = {
+        query: {
+          q: 'getBestChainLock'
+        }
+      };
+      var res = {
+        jsonp: function (data) {
+          data.bestchainlock.should.equal(outSetInfo.bestchainlock);
           done();
         }
       };


### PR DESCRIPTION
This PR adds the `/status?q=getBestChainLock` endpoint returning info about the ChainLock status reported by the node.
This requires https://github.com/dashevo/dashcore-node/pull/76 to work.
A PR integrating this in insight-ui status page will follow shortly.

Tests for this method (similar to other similar endpoints tests) are included.

No breaking changes introduced.