### PR TITLE
build: access npm token only when deploying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,15 @@ branches:
     - /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
 
 before_install:
-  # Login to NPM registry
-  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
   # Use latest supported NPM in order to speedup build and support `npm ci`
   - npm i -g npm@6
 
 install:
   - npm ci
+  
+before_deploy:
+  # Login to NPM registry
+  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 
 deploy:
   - provider: script


### PR DESCRIPTION
### Issue being fixed or implemented  

Currently PRs from external repos cannot successfully run tests because Travis prevents them from accessing the NPM token. 

### What was done  
This attempts to fix that by bypassing token access unless actually deploying (which should only happen from this repo).

### How Has This Been Tested?
This was first implemented on dashevo/dapi-grpc#61.

### Notes  
N/A

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
