### PR TITLE
fix: make maxFeeRate 15x the 1000 duff minimum

### DIFF
--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -355,7 +355,7 @@ TxController.prototype.sendix = function(req, res) {
 			code:1
 		}, res);
 	}
-	var options = {maxFeeRate: 0.00010000, isInstantSend: true};
+	var options = {maxFeeRate: 0.00015000, isInstantSend: true};
 	this.node.sendTransaction(req.body.rawtx, options, function(err, txid) {
 		if(err) {
 			// TODO handle specific errors


### PR DESCRIPTION
I saw the 15x number in some other code. It seems reasonable. Certainly 1000 (the minimum) should not also be the maximum.

Re:
- https://github.com/dashevo/insight-api/pull/86
- https://github.com/dashevo/dashcore-node/pull/90
- https://github.com/dashevo/insight-ui/issues/75