### PR TITLE
chore: bump to v18 to match dashcore v18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dashevo/insight-api",
-  "version": "3.2.1",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dashevo/insight-api",
-      "version": "3.2.1",
+      "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
         "@dashevo/dashcore-lib": "~0.19.41",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/insight-api",
   "description": "A Dash blockchain REST and WebSocket API Service",
-  "version": "3.2.1",
+  "version": "7.0.0",
   "repository": "git://github.com/dashevo/insight-api.git",
   "contributors": [
     {


### PR DESCRIPTION
DashCore v18 had some breaking changes. Let's sync to v18 to signify that any new breaking changes are actually patches to fix for v18.