### PR TITLE
Upgrade dashcore-lib version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/insight-api",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@dashevo/insight-api",
-      "version": "4.0.6",
+      "version": "4.0.7",
       "license": "MIT",
       "dependencies": {
-        "@dashevo/dashcore-lib": "^0.21.1",
+        "@dashevo/dashcore-lib": "^0.22.0",
         "async": "^2.6.2",
         "body-parser": "^1.19.0",
         "compression": "^1.7.4",
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@dashevo/dashcore-lib": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.21.1.tgz",
-      "integrity": "sha512-ZRzzvIkB5NtS04QmBDOPBqyMQTV+yzrUc/T+TbsKcF5FdapQCAzN4HnTsIXKLenPk2TpW/j68yFwoA1tj3eRXA==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.22.0.tgz",
+      "integrity": "sha512-9zvTcr8eFE+aeA/SVN5jsDgB/Kg6ozmsOY4u3gJdFJ6kQSU+yVyFNsflaWhHwRakZ7CVlU88P7AuDKneukp3zQ==",
       "dependencies": {
         "@dashevo/bls": "~1.2.9",
         "@dashevo/x11-hash-js": "^1.0.2",
@@ -3383,9 +3383,9 @@
       }
     },
     "@dashevo/dashcore-lib": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.21.1.tgz",
-      "integrity": "sha512-ZRzzvIkB5NtS04QmBDOPBqyMQTV+yzrUc/T+TbsKcF5FdapQCAzN4HnTsIXKLenPk2TpW/j68yFwoA1tj3eRXA==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.22.0.tgz",
+      "integrity": "sha512-9zvTcr8eFE+aeA/SVN5jsDgB/Kg6ozmsOY4u3gJdFJ6kQSU+yVyFNsflaWhHwRakZ7CVlU88P7AuDKneukp3zQ==",
       "requires": {
         "@dashevo/bls": "~1.2.9",
         "@dashevo/x11-hash-js": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@dashevo/dashcore-lib": "^0.21.1",
+    "@dashevo/dashcore-lib": "^0.22.0",
     "async": "^2.6.2",
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/insight-api",
   "description": "A Dash blockchain REST and WebSocket API Service",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "repository": "git://github.com/dashevo/insight-api.git",
   "contributors": [
     {


### PR DESCRIPTION
# Issue
There is a new dashcore-lib version that implement some missing stuff for an mnHf

https://github.com/dashpay/dashcore-lib/releases/tag/v0.22.0

We need to upgrade dashcore-lib in the project and release a new version

# Things done
* Updated dashcore-lib dependency to 0.22.0
* Bumped package version to 4.0.7