### PR TITLE
build: add curl and cmake in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,10 +2,12 @@ FROM node:16-alpine
 
 RUN apk add --update --no-cache \
                             git \
+                            curl \
                             libzmq \
                             zeromq-dev \
                             python3 \
                             make \
+                            cmake \
                             g++
 
 WORKDIR /insight

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dashevo/insight-api",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dashevo/insight-api",
-      "version": "4.0.7",
+      "version": "4.0.8",
       "license": "MIT",
       "dependencies": {
         "@dashevo/dashcore-lib": "^0.22.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/insight-api",
   "description": "A Dash blockchain REST and WebSocket API Service",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "repository": "git://github.com/dashevo/insight-api.git",
   "contributors": [
     {


### PR DESCRIPTION
# Issue

For some reason, arm v7 builds are failing, because it seems like it fails to pick up prebuilt binary. As a result, npm attempts to build it itself which invokes additional commands like curl and cmake, which does not happen in case prebuilt is found. 

# Things done
* Added curl & cmake dependencies in the docker build stage layer
* Bumped package version to 4.0.8